### PR TITLE
Fix web-animations-js in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "@polymer/paper-tooltip": "^3.0.0-pre.19",
     "@polymer/polymer": "^3.0.2",
     "@webcomponents/webcomponentsjs": "^2.0.0",
-    "web-animations-js": "https://github.com/web-animations/web-animations-js.git#2.3.1"
+    "web-animations-js": "^2.3.2"
   }
 }


### PR DESCRIPTION
Previous version was giving error on `npm install` at least on Windows 10.